### PR TITLE
fix: stop using the deprecated config alias and method call

### DIFF
--- a/custom_components/argoclima/__init__.py
+++ b/custom_components/argoclima/__init__.py
@@ -44,11 +44,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    for platform in type.platforms:
-        coordinator.platforms.append(platform)
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    coordinator.platforms.extend(type.platforms)
+    await hass.config_entries.async_forward_entry_setups(entry, type.platforms)
 
     entry.add_update_listener(async_reload_entry)
 

--- a/custom_components/argoclima/__init__.py
+++ b/custom_components/argoclima/__init__.py
@@ -10,7 +10,7 @@ from custom_components.argoclima.device_type import ArgoDeviceType
 from custom_components.argoclima.service import setup_service
 from custom_components.argoclima.update_coordinator import ArgoDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
+from homeassistant.core_config import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.0
-homeassistant==2024.1.3
+homeassistant==2025.6.0
 pip>=21.0,<23.4
 ruff==0.1.13


### PR DESCRIPTION
So. I am not a python or home assistant expert, and I haven't yet tested this due to needing to go to a vacation next. If anybody would please try this out with 2025.6.0 and see if it works, that would be great. Otherwise I will do it in a bit over a week.

Closes: https://github.com/nyffchanium/argoclima-integration/issues/36